### PR TITLE
fixed bug that led to wrong whereis on Mac OS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 'use strict';
 
-/* global module, child_process, os */
+const os = require('os');
+const child_process = require('child_process');
+
 const {execFile, spawnSync} = child_process;
 
 const execName = 'sdb';
 (function checkSDBAvailable() {
-  const whereis = os.platform().includes('win') ? 'where' : 'which';
+  const whereis = os.platform().includes('win32') ? 'where' : 'which';
   if (spawnSync(whereis, [execName]).status !== 0) {
     throw new Error(`SDB command ${execName} is not available in PATH.`);
   }


### PR DESCRIPTION
Fixed a couple minor bugs: 

* os.platform() on Mac OS returns 'darwin', which includes 'win', leading to the wrong `whereis` being used on Mac and an inability to find `sdb` on that OS. Fixed that by changing the includes search string to 'win32' which applies to both 32 and 64 bit Windows (but not at all to Mac).
* 'os' and 'child_process' modules aren't globally available (though they are included in nodejs distribution), leading to 'os not defined' and 'child_process not defined' errors when run. Fixed this by adding explicit require statements for them. Doing so removed the need for the global hint, so I removed that declaration also. 
